### PR TITLE
Feature/cli

### DIFF
--- a/build-ts.sh
+++ b/build-ts.sh
@@ -17,8 +17,19 @@ function build ()
     cp -r ./packages/${1}/types node_modules/@fmfe/${1}/types
 }
 
+function build-cli()
+{
+    echo "build ${1}"
+    rm -rf ./node_modules/@fmfe/${1}/dist
+
+    tsc --build packages/${1}/tsconfig.json
+    cp -r ./packages/${1}/dist node_modules/@fmfe/${1}/dist
+    cp -r ./packages/${1}/types node_modules/@fmfe/${1}/types
+}
+
 build genesis-core
 build genesis-compiler
 build genesis-app
 build genesis-remote
 build square
+build-cli genesis-cli

--- a/packages/genesis-cli/.vscode/settings.json
+++ b/packages/genesis-cli/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    // 使用项目配置规则
+    "eslint.options": {
+        "configFile": "./.eslintrc.js"
+    },
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true,
+        "source.fixAll.stylelint": true
+    },
+}

--- a/packages/genesis-cli/CHANGELOG.md
+++ b/packages/genesis-cli/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/genesis-cli/README.md
+++ b/packages/genesis-cli/README.md
@@ -1,0 +1,5 @@
+# @fmfe/genesis-cli
+> It's genesis cli can help you run and create the genesis project
+
+## Document
+[简体中文](https://fmfe.github.io/genesis-docs/guide/)| [English](https://anish2690.github.io/genesis-docs-en/)

--- a/packages/genesis-cli/package.json
+++ b/packages/genesis-cli/package.json
@@ -1,0 +1,86 @@
+{
+    "name": "@fmfe/genesis-cli",
+    "version": "0.0.1",
+    "description": "genesis cli",
+    "keywords": [
+        "genesis"
+    ],
+    "files": [
+        "lib",
+        "template"
+    ],
+    "main": "lib/index.js",
+    "typings": "lib/index.d.ts",
+    "bin": {
+        "genesis": "./lib/bin/index.js"
+    },
+    "scripts": {
+        "dev": "tsc --watch",
+        "build": "tsc",
+        "lint": "npm run lint:js && npm run lint:css",
+        "lint:js": "fm-eslint . --ext .js,.ts,.vue --fix",
+        "lint:css": "fm-stylelint . --syntax less --fix --ignore-path ./.stylelintignore | fm-stylelint . --custom-syntax postcss-html --fix"
+    },
+    "author": "Followme",
+    "license": "MIT",
+    "engines": {
+        "node": ">=10"
+    },
+    "devDependencies": {
+        "@types/ejs": "^3.0.7",
+        "@types/express": "^4.17.1",
+        "@types/fs-extra": "^9.0.11",
+        "@types/http-proxy": "^1.17.7"
+    },
+    "dependencies": {
+        "@fmfe/genesis-app": "^1.0.3",
+        "@fmfe/genesis-compiler": "^1.0.3",
+        "@fmfe/genesis-core": "^1.0.3",
+        "@fmfe/genesis-lint": "^1.0.3",
+        "@fmfe/genesis-remote": "^1.0.3",
+        "axios": "^0.21.1",
+        "chokidar": "^3.5.1",
+        "commander": "^6.2.1",
+        "consola": "^2.15.3",
+        "ejs": "^3.1.6",
+        "eslint": "^7.28.0",
+        "express": "^4.17.1",
+        "fast-glob": "^3.2.5",
+        "fs-extra": "^10.0.0",
+        "http-proxy": "^1.18.1",
+        "ora": "^5.4.1",
+        "portfinder": "^1.0.28",
+        "ts-node": "^8.10.2",
+        "typescript": "^4.3.2",
+        "vue-router": "^3.5.2"
+    },
+    "homepage": "https://fmfe.github.io/genesis-docs/",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fmfe/genesis.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fmfe/genesis/issues"
+    },
+    "gitHead": "40994d32c8179be878760268d7e26f3152679321",
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "*.{ts,js}": [
+            "fm-eslint --ext .js,.ts --fix",
+            "git add"
+        ],
+        "*.{css,less}": [
+            "fm-stylelint --syntax less --fix",
+            "git add"
+        ],
+        "*.{vue}": [
+            "fm-eslint --ext .js,.ts --fix",
+            "fm-stylelint --custom-syntax postcss-html --fix",
+            "git add"
+        ]
+    }
+}

--- a/packages/genesis-cli/package.json
+++ b/packages/genesis-cli/package.json
@@ -9,10 +9,10 @@
         "lib",
         "template"
     ],
-    "main": "lib/index.js",
-    "typings": "lib/index.d.ts",
+    "main": "dist/index.js",
+    "typings": "dist/index.d.ts",
     "bin": {
-        "genesis": "./lib/bin/index.js"
+        "genesis": "./dist/bin/index.js"
     },
     "scripts": {
         "dev": "tsc --watch",

--- a/packages/genesis-cli/src/bean/CustomSSR.ts
+++ b/packages/genesis-cli/src/bean/CustomSSR.ts
@@ -1,7 +1,14 @@
 import Genesis, { SSR } from '@fmfe/genesis-core';
 import { ServiceOptions } from '../../types';
 
+/**
+ * CustomSSR
+ */
 export default class CustomSSR extends SSR {
+    /**
+     * create CustomSSR instance by options
+     * @param options
+     */
     static createInstanceByServiceOptions(options: ServiceOptions) {
 
         return new CustomSSR({
@@ -27,6 +34,12 @@ export default class CustomSSR extends SSR {
 
     public noWebpackGenTemplate = true;
 
+    /**
+     * @override
+     * @param options Genesis.Options
+     * @param _entryClientFile client entry file
+     * @param _entryServerFile server entry file
+     */
     public constructor(
         options: Genesis.Options = {},
         private _entryClientFile: string,

--- a/packages/genesis-cli/src/bean/CustomSSR.ts
+++ b/packages/genesis-cli/src/bean/CustomSSR.ts
@@ -1,0 +1,38 @@
+import Genesis, { SSR } from '@fmfe/genesis-core';
+import { ServiceOptions } from '../../types';
+
+export default class CustomSSR extends SSR {
+    static createInstanceByServiceOptions(options: ServiceOptions) {
+
+        return new CustomSSR({
+            name: options.name,
+            build: options.build
+        }, String(options.entryClient), String(options.entryServer));
+    }
+
+    public get entryServerFile(): string {
+        return this._entryServerFile;
+    }
+    public set entryServerFile(value: string) {
+        this._entryServerFile = value;
+    }
+
+    public get entryClientFile(): string {
+        return this._entryClientFile;
+    }
+
+    public set entryClientFile(value: string) {
+        this._entryClientFile = value;
+    }
+
+    public noWebpackGenTemplate = true;
+
+    public constructor(
+        options: Genesis.Options = {},
+        private _entryClientFile: string,
+        private _entryServerFile: string
+    ) {
+        super(options)
+
+    }
+}

--- a/packages/genesis-cli/src/bean/CustomSSR.ts
+++ b/packages/genesis-cli/src/bean/CustomSSR.ts
@@ -32,6 +32,9 @@ export default class CustomSSR extends SSR {
         this._entryClientFile = value;
     }
 
+    /**
+     * 不在 genesis-compiler 自动创建 entryClientFile 和 entryServerFile
+     */
     public noWebpackGenTemplate = true;
 
     /**

--- a/packages/genesis-cli/src/bin/build.ts
+++ b/packages/genesis-cli/src/bin/build.ts
@@ -1,0 +1,19 @@
+import { setNodeEnv, getGenesisConfig } from '../utils';
+import { GenesisConfig } from '../../types';
+import { buildGenesisService } from '../compile';
+
+export async function build() {
+    setNodeEnv('production');
+    let config: GenesisConfig = getGenesisConfig();
+
+    await buildGenesisService(config);
+
+    if (config.models && config.models.length) {
+        for (let i = 0; i < config.models.length; i++) {
+            const modelConfig = config.models[i];
+            await buildGenesisService(modelConfig, true);
+        }
+    }
+
+    process.exit();
+}

--- a/packages/genesis-cli/src/bin/index.ts
+++ b/packages/genesis-cli/src/bin/index.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env ts-node
+import { command, parse, version } from 'commander';
+import cli from '../index'
+
+version(`@genesis/cli ${cli.version}`);
+
+command('serve')
+    .description('run genesis serve')
+    .allowUnknownOption()
+    .action(cli.serve)
+
+command('build')
+    .description('run genesis build to build project')
+    .allowUnknownOption()
+    .action(cli.build)
+
+command('start')
+    .description('run genesis start to start production env')
+    .allowUnknownOption()
+    .action(cli.start)
+
+parse();

--- a/packages/genesis-cli/src/bin/serve.ts
+++ b/packages/genesis-cli/src/bin/serve.ts
@@ -1,0 +1,16 @@
+import { setNodeEnv, getGenesisConfig } from '../utils';
+import { createGenesisServiceInstance } from '../compile';
+
+export async function serve() {
+    setNodeEnv('development');
+    const config = getGenesisConfig();
+
+    await createGenesisServiceInstance(config);
+
+    if (config.models && config.models.length) {
+        for (let i = 0; i < config.models.length; i++) {
+            const modelConfig = config.models[i];
+            await createGenesisServiceInstance(modelConfig);
+        }
+    }
+}

--- a/packages/genesis-cli/src/bin/start.ts
+++ b/packages/genesis-cli/src/bin/start.ts
@@ -1,0 +1,16 @@
+import { setNodeEnv, getGenesisConfig } from '../utils';
+import { createGenesisServiceInstance } from '../compile';
+
+export async function start() {
+    setNodeEnv('production');
+    const config = getGenesisConfig();
+
+    await createGenesisServiceInstance(config);
+
+    if (config.models && config.models.length) {
+        for (let i = 0; i < config.models.length; i++) {
+            const modelConfig = config.models[i];
+            await createGenesisServiceInstance(modelConfig, true);
+        }
+    }
+}

--- a/packages/genesis-cli/src/compile/index.ts
+++ b/packages/genesis-cli/src/compile/index.ts
@@ -4,23 +4,36 @@ import { createService } from '../service';
 import CustomSSR from '../bean/CustomSSR';
 import { Build } from '@fmfe/genesis-compiler';
 
+/**
+ * create GenesisServiceInstance
+ * @param config
+ * @param isModel
+ */
 export async function createGenesisServiceInstance(config: ServiceOptions, isModel = false) {
+    await validateOptions(config);
+    // with default config
     config = resolveConfig(config, isModel);
-
     try {
-        await validateOptions(config);
         return await createService(config);
     } catch (e) {
         console.error(e?.message)
     }
 }
 
+/**
+ * build GenesisService
+ * @param config build config
+ * @param isModel is sub service
+ */
 export async function buildGenesisService(config: ServiceOptions, isModel = false) {
+    await validateOptions(config);
     config = resolveConfig(config, isModel);
 
     try {
+        // create ssr
         const ssr = CustomSSR.createInstanceByServiceOptions(config);
 
+        // build
         const build = new Build(ssr);
         await build.start();
     } catch (e) {

--- a/packages/genesis-cli/src/compile/index.ts
+++ b/packages/genesis-cli/src/compile/index.ts
@@ -1,0 +1,29 @@
+import { ServiceOptions } from '../../types';
+import { resolveConfig, validateOptions } from '../config/serviceConfig';
+import { createService } from '../service';
+import CustomSSR from '../bean/CustomSSR';
+import { Build } from '@fmfe/genesis-compiler';
+
+export async function createGenesisServiceInstance(config: ServiceOptions, isModel = false) {
+    config = resolveConfig(config, isModel);
+
+    try {
+        await validateOptions(config);
+        return await createService(config);
+    } catch (e) {
+        console.error(e?.message)
+    }
+}
+
+export async function buildGenesisService(config: ServiceOptions, isModel = false) {
+    config = resolveConfig(config, isModel);
+
+    try {
+        const ssr = CustomSSR.createInstanceByServiceOptions(config);
+
+        const build = new Build(ssr);
+        await build.start();
+    } catch (e) {
+        console.error(e?.message)
+    }
+}

--- a/packages/genesis-cli/src/config/serveStaticOptions.ts
+++ b/packages/genesis-cli/src/config/serveStaticOptions.ts
@@ -1,0 +1,6 @@
+import { ServeStaticOptions } from 'serve-static';
+
+export const serveStaticOptions: ServeStaticOptions = {
+    immutable: true,
+    maxAge: '31536000000'
+}

--- a/packages/genesis-cli/src/config/serviceConfig.ts
+++ b/packages/genesis-cli/src/config/serviceConfig.ts
@@ -1,0 +1,162 @@
+import type { Service, ServiceOptions } from '../../types';
+import { findConfigDir, injectStart, ROOT } from '../utils';
+import { existsSync, emptyDirSync, readFileSync, writeFileSync } from 'fs-extra';
+import { join, resolve, isAbsolute } from 'path';
+import ejs from 'ejs';
+
+const root = findConfigDir(ROOT);
+
+export const defaultServiceConfig: ServiceOptions = {
+    baseDir: './',
+    name: 'ssr-genesis',
+    port: 8080,
+    isProd: false,
+    api: '',
+    build: {
+        baseDir: root
+    },
+    proxyService: []
+};
+
+export const defaultProxy: Service = {
+    protocol: 'http',
+    host: 'localhost',
+    port: 8080,
+    api: '/'
+}
+
+function getRouterAndAppPath(baseDir: string) {
+    baseDir = isAbsolute(baseDir)
+        ? baseDir
+        : resolve(root, baseDir);
+    const routerPaths = [join(baseDir, 'src/router.ts'), join(baseDir, 'src/router.js'), join(baseDir, 'src/router')];
+    const routerPath = join(baseDir, 'src/router');
+    const appPaths = [join(baseDir, 'src/app.vue'), join(baseDir, 'src/App.vue')];
+    const existRouter = routerPaths.find(path => existsSync(path));
+    const appPath = appPaths.find(path => existsSync(path));
+
+    if (!existRouter) {
+        throw new Error(`The default router ${routerPath} must be exist.`);
+    }
+
+    if (!appPath) {
+        throw new Error(`The default ${join(root, 'src/App.vue')} must be exist.`);
+    }
+
+    return { routerPath, appPath };
+}
+
+function createDefaultEntryClient(name: string, baseDir: string) {
+    const dir = join(root, '.genesis', name, 'client');
+    emptyDirSync(dir);
+    const { routerPath, appPath } = getRouterAndAppPath(baseDir);
+
+    const clientTemplate = readFileSync(join(__dirname, '../../template/entry-client.ejs'));
+
+    const clientFile = ejs.render(clientTemplate.toString('utf-8'), {
+        routerPath,
+        appPath
+    });
+
+    const clientFilePath = join(dir, 'entry-client.js');
+    writeFileSync(clientFilePath, clientFile);
+
+    return clientFilePath;
+}
+
+function createDefaultEntryServer(name: string, baseDir: string) {
+    const dir = join(root, '.genesis', name, 'server');
+    emptyDirSync(dir);
+    const { routerPath, appPath } = getRouterAndAppPath(baseDir);
+
+    const clientTemplate = readFileSync(join(__dirname, '../../template/entry-server.ejs'));
+
+    const clientFile = ejs.render(clientTemplate.toString('utf-8'), {
+        routerPath,
+        appPath
+    });
+
+    const clientFilePath = join(dir, 'entry-server.js');
+    writeFileSync(clientFilePath, clientFile);
+
+    return clientFilePath;
+}
+
+export function resolveApi(options: ServiceOptions) {
+    options.api = options.api.startsWith('/')
+        ? options.api
+        : '/' + options.api;
+
+    return options.api.replace('[name]', options.name);
+}
+
+export function resolveProxy(proxyService: Service[] | Service): Service[] {
+
+    const optionsProxyServices = Array.isArray(proxyService)
+        ? proxyService || []
+        : [proxyService] as Service[];
+
+    return optionsProxyServices.map(service => {
+        return Object.assign({}, defaultProxy, service, {
+            api: injectStart(String(service.api), '/')
+        })
+    })
+}
+
+export function resolveConfig(options: ServiceOptions, isModel?: boolean) {
+    options = Object.assign({}, defaultServiceConfig, options);
+
+    options.isProd = process.env.NODE_ENV === 'production'
+        ? true
+        : !!options.isProd;
+
+    if (!options.entryClient) {
+        options.entryClient = createDefaultEntryClient(options.name, options.baseDir);
+    }
+
+    if (!options.entryServer) {
+        options.entryServer = createDefaultEntryServer(options.name, options.baseDir);
+    }
+
+    options.api = options.api ? resolveApi(options) : '';
+
+    options.build = Object.assign({}, options.build);
+    options.build.baseDir = options.baseDir || './';
+
+    const defaultOutputDir = isModel
+        ? join(ROOT, `./dist/${options.name}`)
+        : resolve(options.build.baseDir, `./dist/${options.name}`);
+
+    options.build.outputDir = options.build.outputDir
+        ? options.build.outputDir
+        : defaultOutputDir;
+
+    options.proxyService = resolveProxy(options.proxyService || [])
+
+    return options;
+}
+
+export async function validateOptions(options: ServiceOptions) {
+    const {
+        entryClient,
+        entryServer,
+        name,
+        api,
+        build,
+
+    } = options;
+
+    if (entryClient && !existsSync(resolve(ROOT, entryClient))) {
+        throw new Error(' EntryClient file is not exist.');
+    }
+
+    if (entryServer && !existsSync(resolve(ROOT, entryServer))) {
+        throw new Error(' EntryServer file is not exist.');
+    }
+
+    if (!/^[\w\-]+$/.test(name)) {
+        throw new Error(' The name can only be combination of a-z A-Z 0-9 - _.');
+    }
+
+
+}

--- a/packages/genesis-cli/src/index.ts
+++ b/packages/genesis-cli/src/index.ts
@@ -1,0 +1,12 @@
+// @ts-ignore
+import packageJson from '../package.json';
+import { serve } from './bin/serve';
+import { build } from './bin/build';
+import { start } from './bin/start';
+
+export default {
+    version: packageJson.version,
+    serve,
+    start,
+    build
+}

--- a/packages/genesis-cli/src/service/express.ts
+++ b/packages/genesis-cli/src/service/express.ts
@@ -1,0 +1,18 @@
+import portfinder from 'portfinder'
+import express, { Express } from 'express';
+
+export async function createExpress (port: number, isAutoPort: boolean = false): Promise<Express> {
+    if (isAutoPort) {
+        portfinder.basePort = port
+        port = await portfinder.getPortPromise()
+    }
+
+    const service = express()
+    try {
+        await service.listen(port)
+    } catch (e) {
+        throw e
+    }
+
+    return service
+}

--- a/packages/genesis-cli/src/service/index.ts
+++ b/packages/genesis-cli/src/service/index.ts
@@ -1,0 +1,96 @@
+import CustomSSR from '../bean/CustomSSR';
+import express, { Express, NextFunction, Request, Response } from 'express';
+import type { Service, ServiceOptions } from '../../types';
+import { createExpress } from './express';
+import { serveStaticOptions } from '../config/serveStaticOptions';
+import { Watch } from '@fmfe/genesis-compiler';
+import { Renderer, RenderMode, RenderOptions } from '@fmfe/genesis-core';
+import httpProxy, { ProxyTarget } from 'http-proxy';
+
+export async function createService(options: ServiceOptions): Promise<Express> {
+    const app = await createExpress(options.port, false);
+
+    const ssr = CustomSSR.createInstanceByServiceOptions(options);
+
+    let proxyService: Service[] = Array.isArray(options.proxyService)
+        ? options.proxyService || []
+        : [options.proxyService] as Service[];
+
+    let renderInstance: Renderer;
+    let watch: Watch;
+
+    if (options.isProd) {
+        proxyService = [];
+        renderInstance = ssr.createRenderer();
+        app.use(
+            renderInstance.staticPublicPath,
+            express.static(renderInstance.staticDir, serveStaticOptions)
+        );
+    } else {
+        watch = new Watch(ssr);
+        await watch.start();
+        renderInstance = watch.renderer;
+        app.use(watch.devMiddleware);
+        app.use(watch.hotMiddleware);
+    }
+
+    if (options.api) {
+        app.use(options.api, (req: Request, res: Response, next: NextFunction) => {
+            renderInstance
+                .render(getDefaultRenderOptions(req))
+                .then(renderResult => {
+                    res.send(renderResult.data);
+                })
+                .catch((e) => {
+                    next(e);
+                });
+        });
+    }
+
+    proxyService.forEach(service => {
+        const httpProxyInstance = httpProxy.createProxyServer({});
+        app.use(service.api, (req, res) => {
+            // TODO use node url model
+            req.url = service.api + req.url
+            httpProxyInstance.web(
+                req,
+                res,
+                {
+                    target: service as ProxyTarget,
+                    changeOrigin: true
+                },
+                (err) => {
+                    res.status(500).send(err.message);
+                }
+            );
+        });
+    });
+
+    app.use(renderInstance.renderMiddleware);
+
+    return app;
+}
+
+export function getDefaultRenderOptions(req: Request): RenderOptions {
+    const modes: RenderMode[] = ['ssr-html', 'ssr-json', 'csr-html', 'csr-json'];
+    // 获取渲染的地址
+    const url = decodeURIComponent(String(req.query.renderUrl || ''));
+    // 获取路由渲染的模式
+    const routerMode =
+        ['abstract', 'history'].indexOf(String(req.query.routerMode)) > -1
+            ? req.query.routerMode
+            : 'history';
+    const renderMode = String(req.query.renderMode) as RenderMode;
+    // 渲染默认
+    const mode: RenderMode = modes.includes(renderMode)
+        ? renderMode as RenderMode
+        : 'ssr-json';
+    // Genesis.RenderOptions
+    return {
+        url,
+        mode,
+        state: {
+            routerMode
+        }
+    };
+}

--- a/packages/genesis-cli/src/service/index.ts
+++ b/packages/genesis-cli/src/service/index.ts
@@ -7,6 +7,10 @@ import { Watch } from '@fmfe/genesis-compiler';
 import { Renderer, RenderMode, RenderOptions } from '@fmfe/genesis-core';
 import httpProxy, { ProxyTarget } from 'http-proxy';
 
+/**
+ * create Service
+ * @param options genesis config
+ */
 export async function createService(options: ServiceOptions): Promise<Express> {
     const app = await createExpress(options.port, false);
 

--- a/packages/genesis-cli/src/utils/constant.ts
+++ b/packages/genesis-cli/src/utils/constant.ts
@@ -1,0 +1,2 @@
+export const ROOT = process.cwd()
+export const CONFIG_FILE_NAME = 'genesis.config.js'

--- a/packages/genesis-cli/src/utils/env.ts
+++ b/packages/genesis-cli/src/utils/env.ts
@@ -1,0 +1,4 @@
+
+export function setNodeEnv(env = 'development') {
+    process.env.NODE_ENV = env;
+}

--- a/packages/genesis-cli/src/utils/index.ts
+++ b/packages/genesis-cli/src/utils/index.ts
@@ -1,0 +1,49 @@
+import fs from 'fs-extra'
+import { CONFIG_FILE_NAME, ROOT } from './constant';
+import { dirname, join } from 'path';
+import { GenesisConfig, ServiceOptions } from '../../types';
+
+export * from './constant'
+export * from './env'
+
+export function injectStart(str: string, startStr: string): string {
+    return str.startsWith(startStr)
+        ? str
+        : startStr + str
+}
+
+export function findConfigDir(dir: string): string {
+    if (fs.existsSync(join(dir, CONFIG_FILE_NAME))) {
+        return dir;
+    }
+
+    const parentDir = dirname(dir);
+
+    return dir === parentDir
+        ? dir
+        : findConfigDir(parentDir);
+}
+
+export function getConfigPath() {
+    const configDir = findConfigDir(ROOT);
+    const configFile = join(configDir, CONFIG_FILE_NAME);
+
+    if (!fs.existsSync(configFile)) {
+        throw new Error('Can not find config file ' + CONFIG_FILE_NAME);
+    }
+
+    return configFile;
+}
+
+export function getGenesisConfig(): GenesisConfig {
+    const configFile = getConfigPath()
+    delete require.cache[configFile];
+
+    try {
+        return require(configFile) as GenesisConfig;
+    } catch (err) {
+        console.error(err?.message)
+        throw err
+    }
+
+}

--- a/packages/genesis-cli/src/utils/index.ts
+++ b/packages/genesis-cli/src/utils/index.ts
@@ -6,12 +6,21 @@ import { GenesisConfig, ServiceOptions } from '../../types';
 export * from './constant'
 export * from './env'
 
+/**
+ * result is ('a', '/') => '/a', ('/a', '/') => '/a'
+ * @param str source string
+ * @param startStr need to str start string
+ */
 export function injectStart(str: string, startStr: string): string {
     return str.startsWith(startStr)
         ? str
         : startStr + str
 }
 
+/**
+ * Automatic upward search
+ * @param dir
+ */
 export function findConfigDir(dir: string): string {
     if (fs.existsSync(join(dir, CONFIG_FILE_NAME))) {
         return dir;
@@ -24,6 +33,9 @@ export function findConfigDir(dir: string): string {
         : findConfigDir(parentDir);
 }
 
+/**
+ * get GenesisConfig path. Automatic upward search
+ */
 export function getConfigPath() {
     const configDir = findConfigDir(ROOT);
     const configFile = join(configDir, CONFIG_FILE_NAME);
@@ -35,6 +47,9 @@ export function getConfigPath() {
     return configFile;
 }
 
+/**
+ * get GenesisConfig content
+ */
 export function getGenesisConfig(): GenesisConfig {
     const configFile = getConfigPath()
     delete require.cache[configFile];

--- a/packages/genesis-cli/src/utils/logger.ts
+++ b/packages/genesis-cli/src/utils/logger.ts
@@ -1,0 +1,71 @@
+// TODO use logger
+// import chalk from 'chalk'
+// import stripAnsi from 'chalk'
+// import EventEmitter from 'events'
+// import readline from 'readline'
+// import { stopSpinner } from 'spinner'
+//
+// export const events = new EventEmitter()
+//
+// function _log (type, tag, message) {
+//     if (process.env.VUE_CLI_API_MODE && message) {
+//         exports.events.emit('log', {
+//             message,
+//             type,
+//             tag
+//         })
+//     }
+// }
+//
+// const format = (label, msg) => {
+//     return msg.split('\n').map((line, i) => {
+//         return i === 0
+//             ? `${label} ${line}`
+//             : line.padStart(stripAnsi(label).length + line.length + 1)
+//     }).join('\n')
+// }
+//
+// const chalkTag = msg => chalk.bgBlackBright.white.dim(` ${msg} `)
+//
+// export const log = (msg = '', tag = null) => {
+//     tag ? console.log(format(chalkTag(tag), msg)) : console.log(msg)
+//     _log('log', tag, msg)
+// }
+//
+// export const info = (msg, tag = null) => {
+//     console.log(format(chalk.bgBlue.black(' INFO ') + (tag ? chalkTag(tag) : ''), msg))
+//     _log('info', tag, msg)
+// }
+//
+// export const done = (msg, tag = null) => {
+//     console.log(format(chalk.bgGreen.black(' DONE ') + (tag ? chalkTag(tag) : ''), msg))
+//     _log('done', tag, msg)
+// }
+//
+// export const warn = (msg, tag = null) => {
+//     console.warn(format(chalk.bgYellow.black(' WARN ') + (tag ? chalkTag(tag) : ''), chalk.yellow(msg)))
+//     _log('warn', tag, msg)
+// }
+//
+// export const error = (msg, tag = null) => {
+//     stopSpinner()
+//     console.error(format(chalk.bgRed(' ERROR ') + (tag ? chalkTag(tag) : ''), chalk.red(msg)))
+//     _log('error', tag, msg)
+//     if (msg instanceof Error) {
+//         console.error(msg.stack)
+//         _log('error', tag, msg.stack)
+//     }
+// }
+//
+// export const clearConsole = title => {
+//     if (process.stdout.isTTY) {
+//         const blank = '\n'.repeat(process.stdout.rows)
+//         console.log(blank)
+//         readline.cursorTo(process.stdout, 0, 0)
+//         readline.clearScreenDown(process.stdout)
+//         if (title) {
+//             console.log(title)
+//         }
+//     }
+// }
+//

--- a/packages/genesis-cli/template/entry-client.ejs
+++ b/packages/genesis-cli/template/entry-client.ejs
@@ -1,0 +1,13 @@
+import { createClientApp } from '@fmfe/genesis-app';
+import { createRouter } from '<%= routerPath %>';
+import App from '<%= appPath %>';
+
+export default async (clientOptions) => {
+    return createClientApp({
+        App,
+        clientOptions,
+        vueOptions: {
+            router: createRouter(clientOptions.state)
+        }
+    });
+};

--- a/packages/genesis-cli/template/entry-server.ejs
+++ b/packages/genesis-cli/template/entry-server.ejs
@@ -1,0 +1,13 @@
+import { createServerApp } from '@fmfe/genesis-app';
+import { createRouter } from '<%= routerPath %>';
+import App from '<%= appPath %>';
+
+export default async (renderContext) => {
+    return createServerApp({
+        App,
+        renderContext,
+        vueOptions: {
+            router: createRouter(renderContext.data.state)
+        }
+    });
+};

--- a/packages/genesis-cli/tsconfig.json
+++ b/packages/genesis-cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"target": "ES2019",
+		"module": "commonjs",
+        "moduleResolution": "node",
+        "strict": true,
+        "declaration": false,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"removeComments": false,
+		"experimentalDecorators": true,
+		"outDir": "./dist",
+        "lib": ["esnext"]
+	},
+    "include": ["./src/**/*"],
+    "exclude": ["node_modules"]
+}

--- a/packages/genesis-cli/types/index.d.ts
+++ b/packages/genesis-cli/types/index.d.ts
@@ -1,0 +1,24 @@
+import type { BuildOptions } from '@fmfe/genesis-core/src';
+
+export interface Service extends ProxyTargetDetailed {
+    protocol?: string,
+    name?: string;
+    host?: string,
+    port: number;
+    api: string;
+}
+
+export interface ServiceOptions extends Service {
+    name: string;
+    baseDir: string;
+    entryClient?: string,
+    entryServer?: string,
+    isProd?: boolean;
+    cdnPublicPath?: string;
+    proxyService?: Service[] | Service,
+    build: BuildOptions;
+}
+
+export interface GenesisConfig extends ServiceOptions {
+    models: ServiceOptions[]
+}

--- a/packages/genesis-compiler/src/plugins/template.ts
+++ b/packages/genesis-compiler/src/plugins/template.ts
@@ -81,9 +81,10 @@ export class TemplatePlugin extends Plugin {
             write.sync(output, text);
             return true;
         };
+        if (!writeSrcTemplate('app.vue')) return;
+        if ((ssr as any /* genesis-cli CustomSSR */).noWebpackGenTemplate) return;
         if (!writeSrcTemplate('entry-client.ts')) return;
         if (!writeSrcTemplate('entry-server.ts')) return;
-        if (!writeSrcTemplate('app.vue')) return;
         writeSrcTemplate('shims-vue.d.ts');
     }
 


### PR DESCRIPTION
hi,您好,我抽了点时间,简单的实现了一个cli, 我认为作为一个开源项目在保证完整的“自由度”情况下,可以提供更傻瓜式的内容给到使用者,您写的项目非常不错,思想在我看来非常超前,如果您能整合下包就更好了,我认为genesis-app和genesis-core是分不开的实际是不是可以合成一个呢? 在compiler中是否能提供更多的选择的配置呢?当然这完全取决于您.
还有一点我有点疑问,为什么项目选择必须依赖router,如果我只想做一个单组件项目服务,现阶段也必须完全的依赖router来创建.

最后再解释下我为什么会开发一个cli:

1. 我发现包名为@fmfe/*,并且在创建一个项目时需要引入好几个包才能运行,后面可以通过cli去拓展create命令来创建项目(这个pr还没有实现)
2. 对于服务入口和客户端实例创建文件,所有都大同小异,所以我生成了一个.genesis文件夹专门用来存放这些文件
3. cli能统一的管理这些子项目,我想做到非必要的引入不在项目中引入,只在cli中引入即可,如果项目只引入remote即可运行,那真的太友好了(这个pr还没有实现)
4. 针对配置文件转换为服务,这是最友好的方式,例如webpack等等,其实是需要帮广大开发者去选择,很多人可能连express是什么都不太明白,但是有配置文件的话,就都明白了

太晚了,配置文件校验没时间写了 

您也可以选择不合并此次pr, 当然此次只是新增了一个packages, 更改了complier中对于template的创建, 同时修改了 build-ts.sh 打包脚本

